### PR TITLE
Added matplotlib style file  

### DIFF
--- a/template/config/manuscript.mplstyle
+++ b/template/config/manuscript.mplstyle
@@ -14,7 +14,7 @@ lines.linewidth   : 1.25     # line width in points
 #lines.dash_capstyle : butt          # butt|round|projecting
 #lines.solid_joinstyle : miter       # miter|round|bevel
 #lines.solid_capstyle : projecting   # butt|round|projecting
-#lines.antialiased : True         # render lines in antialised (no jaggies)
+#lines.antialiased : True         # render lines in antialiased (no jaggies)
 
 ### FONT
 #

--- a/template/config/manuscript.mplstyle
+++ b/template/config/manuscript.mplstyle
@@ -279,7 +279,7 @@ savefig.dpi         : 600      # figure dots per inch
 savefig.format      : pdf      # png, ps, pdf, svg
 savefig.bbox        : tight # 'tight' or 'standard'.
                                 # 'tight' is incompatible with pipe-based animation
-                                # backends but will workd with temporary file based ones:
+                                # backends but will work with temporary file based ones:
                                 # e.g. setting animation.writer to ffmpeg will not work,
                                 # use ffmpeg_file instead
 #savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'

--- a/template/config/manuscript.mplstyle
+++ b/template/config/manuscript.mplstyle
@@ -1,0 +1,321 @@
+#### CONFIGURATION BEGINS HERE
+
+
+### LINES
+# See http://matplotlib.org/api/artist_api.html#module-matplotlib.lines for more
+# information on line properties.
+lines.linewidth   : 1.25     # line width in points
+#lines.linestyle   : -       # solid line
+#lines.color       : blue    # has no affect on plot(); see axes.color_cycle
+#lines.marker      : None    # the default marker
+#lines.markeredgewidth  : 0.5     # the line width around the marker symbol
+#lines.markersize  : 6            # markersize, in points
+#lines.dash_joinstyle : miter        # miter|round|bevel
+#lines.dash_capstyle : butt          # butt|round|projecting
+#lines.solid_joinstyle : miter       # miter|round|bevel
+#lines.solid_capstyle : projecting   # butt|round|projecting
+#lines.antialiased : True         # render lines in antialised (no jaggies)
+
+### FONT
+#
+# font properties used by text.Text.  See
+# http://matplotlib.org/api/font_manager_api.html for more
+# information on font properties.  The 6 font properties used for font
+# matching are given below with their default values.
+#
+# The font.family property has five values: 'serif' (e.g., Times),
+# 'sans-serif' (e.g., Helvetica), 'cursive' (e.g., Zapf-Chancery),
+# 'fantasy' (e.g., Western), and 'monospace' (e.g., Courier).  Each of
+# these font families has a default list of font names in decreasing
+# order of priority associated with them.  When text.usetex is False,
+# font.family may also be one or more concrete font names.
+#
+#
+# The font.size property is the default font size for text, given in pts.
+# 12pt is the standard value.
+#
+font.family         : serif
+#font.style          : normal
+#font.variant        : normal
+#font.weight         : medium
+#font.stretch        : normal
+# note that font.size controls default text sizes.  To configure
+# special text sizes tick labels, axes, labels, title, etc, see the rc
+# settings for axes and ticks. Special text sizes can be defined
+# relative to font.size, using the following values: xx-small, x-small,
+# small, medium, large, x-large, xx-large, larger, or smaller
+font.size           : 10
+font.serif          : Times New Roman # Times #Times New Roman #, Bitstream Vera Serif, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
+#font.sans-serif     : Bitstream Vera Sans, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
+#font.cursive        : Apple Chancery, Textile, Zapf Chancery, Sand, cursive
+#font.fantasy        : Comic Sans MS, Chicago, Charcoal, Impact, Western, fantasy
+#font.monospace      : Bitstream Vera Sans Mono, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+
+### TEXT
+# text properties used by text.Text.  See
+# http://matplotlib.org/api/artist_api.html#module-matplotlib.text for more
+# information on text properties
+
+#text.color          : black
+
+### LaTeX customizations. See http://www.scipy.org/Wiki/Cookbook/Matplotlib/UsingTex
+text.usetex         : True  # use latex for all text handling. The following fonts
+                              # are supported through the usual rc parameter settings:
+                              # new century schoolbook, bookman, times, palatino,
+                              # zapf chancery, charter, serif, sans-serif, helvetica,
+                              # avant garde, courier, monospace, computer modern roman,
+                              # computer modern sans serif, computer modern typewriter
+                              # If another font is desired which can loaded using the
+                              # LaTeX \usepackage command, please inquire at the
+                              # matplotlib mailing list
+#text.latex.unicode : False
+#text.latex.preamble :  # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
+                            # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
+                            # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
+                            # preamble is a comma separated list of LaTeX statements
+                            # that are included in the LaTeX document preamble.
+                            # An example:
+                            # text.latex.preamble : \usepackage{bm},\usepackage{euler}
+                            # The following packages are always loaded with usetex, so
+                            # beware of package collisions: color, geometry, graphicx,
+                            # type1cm, textcomp. Adobe Postscript (PSSNFS) font packages
+                            # may also be loaded, depending on your font settings
+
+#text.dvipnghack : None      # some versions of dvipng don't handle alpha
+                             # channel properly.  Use True to correct
+                             # and flush ~/.matplotlib/tex.cache
+                             # before testing and False to force
+                             # correction off.  None will try and
+                             # guess based on your dvipng version
+
+#text.hinting : auto   # May be one of the following:
+                       #   'none': Perform no hinting
+                       #   'auto': Use freetype's autohinter
+                       #   'native': Use the hinting information in the
+                       #             font file, if available, and if your
+                       #             freetype library supports it
+                       #   'either': Use the native hinting information,
+                       #             or the autohinter if none is available.
+                       # For backward compatibility, this value may also be
+                       # True === 'auto' or False === 'none'.
+#text.hinting_factor : 8 # Specifies the amount of softness for hinting in the
+                         # horizontal direction.  A value of 1 will hint to full
+                         # pixels.  A value of 2 will hint to half pixels etc.
+
+#text.antialiased : True # If True (default), the text will be antialiased.
+                         # This only affects the Agg backend.
+
+# The following settings allow you to select the fonts in math mode.
+# They map from a TeX font name to a fontconfig font pattern.
+# These settings are only used if mathtext.fontset is 'custom'.
+# Note that this "custom" mode is unsupported and may go away in the
+# future.
+#mathtext.cal : cursive
+mathtext.rm  : serif
+#mathtext.tt  : monospace
+mathtext.it  : serif:italic
+mathtext.bf  : serif:bold
+#mathtext.sf  : sans
+#mathtext.fontset : cm # Should be 'cm' (Computer Modern), 'stix',
+                       # 'stixsans' or 'custom'
+#mathtext.fallback_to_cm : True  # When True, use symbols from the Computer Modern
+                                 # fonts when a symbol can not be found in one of
+                                 # the custom math fonts.
+
+#mathtext.default : it # The default font to use for math.
+                       # Can be any of the LaTeX font names, including
+                       # the special name "regular" for the same font
+                       # used in regular text.
+
+### AXES
+# default face and edge color, default tick sizes,
+# default fontsizes for ticklabels, and so on.  See
+# http://matplotlib.org/api/axes_api.html#module-matplotlib.axes
+#axes.hold           : True    # whether to clear the axes by default on
+#axes.facecolor      : white   # axes background color
+#axes.edgecolor      : black   # axes edge color
+#axes.linewidth      : 1.0     # edge linewidth
+#axes.grid           : False   # display grid or not
+axes.titlesize      : 10   # fontsize of the axes title
+axes.labelsize      : 10  # fontsize of the x any y labels
+#axes.labelweight    : normal  # weight of the x and y labels
+#axes.labelcolor     : black
+#axes.axisbelow      : False   # whether axis gridlines and ticks are below
+                               # the axes elements (lines, text, etc)
+
+#axes.formatter.limits : -7, 7 # use scientific notation if log10
+                               # of the axis range is smaller than the
+                               # first or larger than the second
+#axes.formatter.use_locale : False # When True, format tick labels
+                                   # according to the user's locale.
+                                   # For example, use ',' as a decimal
+                                   # separator in the fr_FR locale.
+#axes.formatter.use_mathtext : True # When True, use mathtext for scientific
+                                     # notation.
+#axes.formatter.useoffset      : True    # If True, the tick label formatter
+                                         # will default to labeling ticks relative
+                                         # to an offset when the data range is very
+                                         # small compared to the minimum absolute
+                                         # value of the data.
+
+#axes.unicode_minus  : True    # use unicode for the minus symbol
+                               # rather than hyphen.  See
+                               # http://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
+#axes.color_cycle    : b, g, r, c, m, y, k  # color cycle for plot lines
+                                            # as list of string colorspecs:
+                                            # single letter, long name, or
+                                            # web-style hex
+#axes.prop_cycle : cycler(linestyle=[])
+#axes.xmargin        : 0  # x margin.  See `axes.Axes.margins`
+#axes.ymargin        : 0  # y margin See `axes.Axes.margins`
+
+#polaraxes.grid      : True    # display grid on polar axes
+#axes3d.grid         : True    # display grid on 3d axes
+
+### TICKS
+# see http://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
+#xtick.major.size     : 4      # major tick size in points
+#xtick.minor.size     : 2      # minor tick size in points
+#xtick.major.width    : 0.5    # major tick width in points
+#xtick.minor.width    : 0.5    # minor tick width in points
+#xtick.major.pad      : 4      # distance to major tick label in points
+#xtick.minor.pad      : 4      # distance to the minor tick label in points
+#xtick.color          : k      # color of the tick labels
+xtick.labelsize      : 10 # fontsize of the tick labels
+#xtick.direction      : in     # direction: in, out, or inout
+
+#ytick.major.size     : 4      # major tick size in points
+#ytick.minor.size     : 2      # minor tick size in points
+#ytick.major.width    : 0.5    # major tick width in points
+#ytick.minor.width    : 0.5    # minor tick width in points
+#ytick.major.pad      : 4      # distance to major tick label in points
+#ytick.minor.pad      : 4      # distance to the minor tick label in points
+#ytick.color          : k      # color of the tick labels
+ytick.labelsize      : 10 # fontsize of the tick labels
+#ytick.direction      : in     # direction: in, out, or inout
+
+
+### GRIDS
+#grid.color       :   black   # grid color
+#grid.linestyle   :   :       # dotted
+#grid.linewidth   :   0.5     # in points
+#grid.alpha       :   1.0     # transparency, between 0.0 and 1.0
+
+### Legend
+legend.fancybox      : False  # if True, use a rounded box for the
+                               # legend, else a rectangle
+#legend.isaxes        : True
+#legend.numpoints     : 2      # the number of points in the legend line
+legend.fontsize      : 10.0
+#legend.borderpad     : 0.5    # border whitespace in fontsize units
+#legend.markerscale   : 1.0    # the relative size of legend markers vs. original
+# the following dimensions are in axes coords
+#legend.labelspacing  : 0.5    # the vertical space between the legend entries in fraction of fontsize
+#legend.handlelength  : 2.     # the length of the legend lines in fraction of fontsize
+#legend.handleheight  : 0.7     # the height of the legend handle in fraction of fontsize
+#legend.handletextpad : 0.8    # the space between the legend line and legend text in fraction of fontsize
+#legend.borderaxespad : 0.5   # the border between the axes and legend edge in fraction of fontsize
+#legend.columnspacing : 2.    # the border between the axes and legend edge in fraction of fontsize
+#legend.shadow        : False
+#legend.frameon       : True   # whether or not to draw a frame around legend
+legend.framealpha    : 1.0    # opacity of of legend frame
+#legend.scatterpoints : 3 # number of scatter points
+
+### FIGURE
+# See http://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
+#figure.figsize   : 8, 6    # figure size in inches
+#figure.dpi       : 80      # figure dots per inch
+#figure.facecolor : 0.75    # figure facecolor; 0.75 is scalar gray
+#figure.edgecolor : white   # figure edgecolor
+#figure.autolayout : False  # When True, automatically adjust subplot
+                            # parameters to make the plot fit the figure
+#figure.max_open_warning : 20  # The maximum number of figures to open through
+                               # the pyplot interface before emitting a warning.
+                               # If less than one this feature is disabled.
+
+# The figure subplot parameters.  All dimensions are a fraction of the
+# figure width or height
+#figure.subplot.left    : 0.125  # the left side of the subplots of the figure
+#figure.subplot.right   : 0.9    # the right side of the subplots of the figure
+#figure.subplot.bottom  : 0.1    # the bottom of the subplots of the figure
+#figure.subplot.top     : 0.9    # the top of the subplots of the figure
+#figure.subplot.wspace  : 0.2    # the amount of width reserved for blank space between subplots
+#figure.subplot.hspace  : 0.2    # the amount of height reserved for white space between subplots
+
+### IMAGES
+#image.aspect : equal             # equal | auto | a number
+#image.interpolation  : bilinear  # see help(imshow) for options
+#image.cmap   : jet               # gray | jet etc...
+#image.lut    : 256               # the size of the colormap lookup table
+#image.origin : upper             # lower | upper
+#image.resample  : False
+
+### CONTOUR PLOTS
+contour.negative_linestyle :  dashed # dashed | solid
+
+
+### SAVING FIGURES
+path.simplify : True
+#path.simplify_threshold : 0.1  # The threshold of similarity below which
+                                # vertices will be removed in the simplification
+                                # process
+#path.snap : True # When True, rectilinear axis-aligned paths will be snapped to
+                  # the nearest pixel when certain criteria are met.  When False,
+                  # paths will never be snapped.
+#path.sketch : None # May be none, or a 3-tuple of the form (scale, length,
+                    # randomness).
+                    # *scale* is the amplitude of the wiggle
+                    # perpendicular to the line (in pixels).  *length*
+                    # is the length of the wiggle along the line (in
+                    # pixels).  *randomness* is the factor by which
+                    # the length is randomly scaled.
+
+# the default savefig params can be different from the display params
+# e.g., you may want a higher resolution, or to make the figure
+# background white
+savefig.dpi         : 600      # figure dots per inch
+#savefig.facecolor   : white    # figure facecolor when saving
+#savefig.edgecolor   : white    # figure edgecolor when saving
+savefig.format      : pdf      # png, ps, pdf, svg
+savefig.bbox        : tight # 'tight' or 'standard'.
+                                # 'tight' is incompatible with pipe-based animation
+                                # backends but will workd with temporary file based ones:
+                                # e.g. setting animation.writer to ffmpeg will not work,
+                                # use ffmpeg_file instead
+#savefig.pad_inches  : 0.1      # Padding to be used when bbox is set to 'tight'
+#savefig.jpeg_quality: 95       # when a jpeg is saved, the default quality parameter.
+#savefig.directory   : ~        # default directory in savefig dialog box,
+                                # leave empty to always use current working directory
+#savefig.transparent : False    # setting that controls whether figures are saved with a
+                                # transparent background by default
+
+# tk backend params
+#tk.window_focus   : False    # Maintain shell focus for TkAgg
+
+# pdf backend params
+#pdf.compression   : 6 # integer from 0 to 9
+                       # 0 disables compression (good for debugging)
+pdf.fonttype       : 42         # Output Type 3 (Type3) or Type 42 (TrueType)
+
+# Control location of examples data files
+#examples.directory : ''   # directory to look in for custom installation
+
+###ANIMATION settings
+#animation.writer : ffmpeg         # MovieWriter 'backend' to use
+#animation.codec : mpeg4           # Codec to use for writing movie
+#animation.bitrate: -1             # Controls size/quality tradeoff for movie.
+                                   # -1 implies let utility auto-determine
+#animation.frame_format: 'png'     # Controls frame format used by temp files
+#animation.ffmpeg_path: 'ffmpeg'   # Path to ffmpeg binary. Without full path
+                                   # $PATH is searched
+#animation.ffmpeg_args: ''         # Additional arguments to pass to ffmpeg
+#animation.avconv_path: 'avconv'   # Path to avconv binary. Without full path
+                                   # $PATH is searched
+#animation.avconv_args: ''         # Additional arguments to pass to avconv
+#animation.mencoder_path: 'mencoder'
+                                   # Path to mencoder binary. Without full path
+                                   # $PATH is searched
+#animation.mencoder_args: ''       # Additional arguments to pass to mencoder
+#animation.convert_path: 'convert' # Path to ImageMagick's convert binary.
+                                   # On Windows use the full path since convert
+                                   # is also the name of a system tool.


### PR DESCRIPTION
Works well for manuscript figures or other documents with 10 pt font sizes.

Currently it includes all matplotlib config parameters (commented out for ones that aren't used.) 
We can consider removing these for clarity/brevity.